### PR TITLE
[Prevent NULL-ptr dereference] check return value jpeg_read_coefficients

### DIFF
--- a/quantsmooth.c
+++ b/quantsmooth.c
@@ -528,6 +528,10 @@ int main(int argc, char **argv) {
 
 	(void) jpeg_read_header(&srcinfo, TRUE);
 	coef_arrays = jpeg_read_coefficients(&srcinfo);
+    if (coef_arrays == NULL) {
+        logfmt(LS ": can't read coefficients\n", progname);
+        return 1;
+    }
 	do_quantsmooth(&srcinfo, coef_arrays, &opts);
 
 	jpeg_copy_critical_parameters(&srcinfo, &dstinfo);


### PR DESCRIPTION
`jpeg_read_coefficents` can return `NULL` in certain conditions. If we continue without checking the return value, this could lead to NULL-pointer dereference further down the execution.

This fix checks the return value of call to `jpeg_read_coefficents` and exits in case it is `NULL`.